### PR TITLE
P3 Dockerfile Update

### DIFF
--- a/p3/Dockerfile
+++ b/p3/Dockerfile
@@ -23,9 +23,7 @@ RUN env-p3/bin/pip install -r requirements.txt
 COPY package.json .
 COPY package-lock.json .
 
-USER root:root
-RUN npm install .
-USER autograder:autograder
+RUN npm ci .
 
 # Install chromedriver (same major version as Google Chrome)
 # Since internet access is disabled on the autograder, we need to copy


### PR DESCRIPTION
Continuation #16. 

As per James suggestion:
> I notice in your Dockerfile that you use npm install instead of npm ci. I tested out that change locally and on the autograder, and the image builds successfully without having to run npm as root

