### PR TITLE
Bump AG to Ubuntu 22.04

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,5 +1,5 @@
 # Build base image
-FROM eecsautograder/ubuntu20:latest
+FROM eecsautograder/ubuntu22:latest
 
 # Set ARG and ENV variables required for tzdata installation (required for Python 3.9+)
 # Source: https://serverfault.com/a/1016972


### PR DESCRIPTION
Updates to Ubuntu 22.04 on the AG. Requires us to setup the AG for P1 again @MattyMay 