### PR TITLE
Revert "Bump AG to Ubuntu 22.04"

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,5 +1,5 @@
 # Build base image
-FROM eecsautograder/ubuntu22:latest
+FROM eecsautograder/ubuntu20:latest
 
 # Set ARG and ENV variables required for tzdata installation (required for Python 3.9+)
 # Source: https://serverfault.com/a/1016972


### PR DESCRIPTION
Reverts eecs485staff/ag-docker-images#22.

I'm having an issue building the sandbox image on the AG. `pip` is throwing `RuntimeError: can't start new thread` which I suspect is because the Docker version on the AG is out of date -- see https://github.com/eecs-autograder/autograder.io/issues/37

For the time being I think we should revert the PR.