### PR TITLE
Revert "Revert "Bump AG to Ubuntu 22.04""

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,5 +1,5 @@
 # Build base image
-FROM eecsautograder/ubuntu20:latest
+FROM eecsautograder/ubuntu22:latest
 
 # Set ARG and ENV variables required for tzdata installation (required for Python 3.9+)
 # Source: https://serverfault.com/a/1016972


### PR DESCRIPTION
Reverts eecs485staff/ag-docker-images#23

Can be merged if https://github.com/eecs-autograder/autograder.io/issues/37 is resolved with enough time to set up the AG before the semester starts. Otherwise we'll save this for W23.