### PR TITLE
Revert "Bump AG to Ubuntu 22.04"

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,5 +1,5 @@
 # Build base image
-FROM eecsautograder/ubuntu22:latest
+FROM eecsautograder/ubuntu20:latest
 
 # Set ARG and ENV variables required for tzdata installation (required for Python 3.9+)
 # Source: https://serverfault.com/a/1016972


### PR DESCRIPTION
Reverts eecs485staff/ag-docker-images#22

No word from James yet about bumping Docker across all the AG nodes, so I think we should release P2 on 20.04.