### PR TITLE
Install `file` program in base image 

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -6,10 +6,10 @@ FROM eecsautograder/ubuntu22:latest
 ARG DEBIAN_FRONTEND=noninteractive
 ENV TZ=America/Detroit
 
-# Install common build tools, sqlite, and tzdata
+# Install common build tools, sqlite, tzdata
 RUN apt-get update && apt-get install -y build-essential software-properties-common sqlite3 tzdata
 
-# Install Python and Java (required by html5validator)
+# Install Python, Java (required by html5validator), and file (used in tests)
 RUN add-apt-repository ppa:deadsnakes/ppa && apt-get update
 ENV PYTHON python3.10
-RUN apt-get install -y $PYTHON $PYTHON-venv openjdk-8-jre
+RUN apt-get install -y $PYTHON $PYTHON-venv openjdk-8-jre file

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -6,7 +6,7 @@ FROM eecsautograder/ubuntu22:latest
 ARG DEBIAN_FRONTEND=noninteractive
 ENV TZ=America/Detroit
 
-# Install common build tools, sqlite, tzdata
+# Install common build tools, sqlite, and tzdata
 RUN apt-get update && apt-get install -y build-essential software-properties-common sqlite3 tzdata
 
 # Install Python, Java (required by html5validator), and file (used in tests)


### PR DESCRIPTION
We use `file` in `test_scripts.py` for multiple projects. Make sure it's installed when we create images.